### PR TITLE
Update to new image with goreleaser 1.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     - auth:
         password: $DOCKER_PASSWORD
         username: $DOCKER_USERNAME
-      image: trussworks/circleci:29ab89fdada1f85c5d8fb685a2c71660f0c5f60c
+      image: trussworks/circleci:ea2483b4886b26b1006ae95e841497e61512b8c6
     steps:
     - checkout
     - setup_remote_docker
@@ -23,7 +23,7 @@ jobs:
     - auth:
         password: $DOCKER_PASSWORD
         username: $DOCKER_USERNAME
-      image: trussworks/circleci:29ab89fdada1f85c5d8fb685a2c71660f0c5f60c
+      image: trussworks/circleci:ea2483b4886b26b1006ae95e841497e61512b8c6
     steps:
     - checkout
     - restore_cache:
@@ -37,7 +37,7 @@ jobs:
         paths:
         - ~/.cache/pre-commit
 references:
-  circleci: trussworks/circleci:29ab89fdada1f85c5d8fb685a2c71660f0c5f60c
+  circleci: trussworks/circleci:ea2483b4886b26b1006ae95e841497e61512b8c6
 version: 2.1
 workflows:
   release:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,7 +23,7 @@ brews:
       email: infra+github@truss.works
 dockers:
   -
-    binaries:
+    ids:
       - health-checker
     image_templates:
       - "trussworks/health-checker:{{ .Tag }}"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # goreleaser removes the `v` prefix when building and this does too
-VERSION = 0.0.1
+VERSION = 0.0.2
 
 ifdef CIRCLECI
 	UNAME_S := $(shell uname -s)


### PR DESCRIPTION
GoReleaser has a new version that will hopefully generate homebrew tap files that don't use deprecated configurations. This pr updated the circle ci config to use the new image with goreleaser 1.1.0 and makes the needed changes to the goreleaser config. Expectation is that once this is released the brew tap will not have deprecated code.

See https://github.com/trussworks/docker-circleci/pull/34
See https://goreleaser.com/deprecations/