### PR TITLE
ci: use semver versioning for updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,24 +10,20 @@
       ],
       "reviewers": [
         "team:waddlers"
-      ]
+      ],
+      "versioning": "semver"
     },
     {
       "automerge": true,
       "description": "Group minor and patch updates into a single PR",
       "groupName": "dependencies",
-      "managers": [
-        "terraform",
-        "pre-commit",
-        "gomod",
-        "dockerfile"
-      ],
       "matchUpdateTypes": [
         "minor",
         "patch",
         "pin",
         "digest"
-      ]
+      ],
+      "versioning": "semver"
     }
   ],
   "pre-commit": {


### PR DESCRIPTION
Uses semver for versioning. Hopefully fixes the nightly build tags that's occurring with alpine updates.
